### PR TITLE
chore: Remove /api/users GET test

### DIFF
--- a/server/src/modules/users/application/use-cases/create-user/create-user-controller.ts
+++ b/server/src/modules/users/application/use-cases/create-user/create-user-controller.ts
@@ -41,9 +41,4 @@ export class CreateUserController extends BaseController {
       return this.fail(res, err)
     }
   }
-
-  async test(_req: express.Request, res: express.Response): Promise<express.Response> {
-    const result = await this.useCase.test()
-    return res.send(result)
-  }
 }

--- a/server/src/modules/users/application/use-cases/create-user/create-user-use-case.ts
+++ b/server/src/modules/users/application/use-cases/create-user/create-user-use-case.ts
@@ -59,8 +59,4 @@ export class CreateUserUseCase
       return Result.err(new AppError.UnexpectedError(err))
     }
   }
-
-  async test(): Promise<any> {
-    return await this.userRepo.findAll()
-  }
 }

--- a/server/src/modules/users/infra/http/routes/index.ts
+++ b/server/src/modules/users/infra/http/routes/index.ts
@@ -7,10 +7,6 @@ userRouter.post('/', (req, res) => {
   createUserController.execute(req, res)
 })
 
-userRouter.get('/', (req, res) => {
-  createUserController.test(req, res)
-})
-
 // userRouter.get('/me', middleware.ensureAuthenticated(), (req, res) =>
 //   getCurrentUserController.execute(req, res)
 // )

--- a/server/src/modules/users/infra/repos/user-repo.ts
+++ b/server/src/modules/users/infra/repos/user-repo.ts
@@ -5,5 +5,4 @@ export abstract class UserRepo {
   abstract exists(userEmail: UserEmail): Promise<boolean>
   abstract getUserByUserId(userId: string): Promise<User>
   abstract save(user: User): Promise<void>
-  abstract findAll(): Promise<Array<User>>
 }


### PR DESCRIPTION
This removes the GET `/api/users` test endpoint. This `userRepo.findAll` was causing the type error. (I added this last minute to verify creating users worked). We can add it back in later.