### PR TITLE
Add req body validation with Joi to BaseController

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
     "bcrypt": "^5.0.0",
     "express": "^4.17.1",
     "graphql": "^15.4.0",
+    "joi": "^17.3.0",
     "node-mocks-http": "^1.9.0",
     "typescript": "^4.1.3",
     "uuid": "^8.3.2"

--- a/server/src/modules/users/application/use-cases/create-user/__tests__/create-user-controller.test.unit.ts
+++ b/server/src/modules/users/application/use-cases/create-user/__tests__/create-user-controller.test.unit.ts
@@ -35,7 +35,7 @@ describe('CreateUserController', () => {
     jest.spyOn(CreateUserUseCase.prototype, 'execute').mockResolvedValue(Result.ok(mockUser))
     const createUserController = buildController()
 
-    const result = await createUserController.executeImpl(mockRequest, mockResponse)
+    const result = await createUserController.execute(mockRequest, mockResponse)
 
     expect(result.statusCode).toBe(200)
   })
@@ -50,7 +50,24 @@ describe('CreateUserController', () => {
       .mockResolvedValue(Result.err(new UserValueObjectErrors.InvalidEmail(createUserDTO.email)))
     const createUserController = buildController()
 
-    const result = await createUserController.executeImpl(mockRequest, mockResponse)
+    const result = await createUserController.execute(mockRequest, mockResponse)
+
+    expect(result.statusCode).toBe(400)
+  })
+
+  test('When the DTO is invalid, CreateUserController returns 400 Bad Request', async () => {
+    const invalidCreateUserDTO = {
+      email: 123,
+      password: 456,
+    }
+    const mockRequest = httpMocks.createRequest({
+      body: invalidCreateUserDTO,
+    }) as DecodedExpressRequest
+    const mockResponse = httpMocks.createResponse()
+    jest.spyOn(CreateUserUseCase.prototype, 'execute').mockResolvedValue(Result.ok(mockUser))
+    const createUserController = buildController()
+
+    const result = await createUserController.execute(mockRequest, mockResponse)
 
     expect(result.statusCode).toBe(400)
   })
@@ -67,8 +84,7 @@ describe('CreateUserController', () => {
       )
     const createUserController = buildController()
 
-    const result = await createUserController.executeImpl(mockRequest, mockResponse)
-
+    const result = await createUserController.execute(mockRequest, mockResponse)
     expect(result.statusCode).toBe(400)
   })
 
@@ -84,7 +100,7 @@ describe('CreateUserController', () => {
       )
     const createUserController = buildController()
 
-    const result = await createUserController.executeImpl(mockRequest, mockResponse)
+    const result = await createUserController.execute(mockRequest, mockResponse)
 
     expect(result.statusCode).toBe(409)
   })
@@ -99,7 +115,7 @@ describe('CreateUserController', () => {
       .mockResolvedValue(Result.err(new AppError.UnexpectedError('Unexpected error')))
     const createUserController = buildController()
 
-    const result = await createUserController.executeImpl(mockRequest, mockResponse)
+    const result = await createUserController.execute(mockRequest, mockResponse)
 
     expect(result.statusCode).toBe(500)
   })

--- a/server/src/modules/users/application/use-cases/create-user/create-user-controller.ts
+++ b/server/src/modules/users/application/use-cases/create-user/create-user-controller.ts
@@ -1,12 +1,13 @@
 import express from 'express'
+import { ValidationError } from 'joi'
 import { BaseController } from '../../../../../shared/app/base-controller'
 import { CreateUserUseCase } from './create-user-use-case'
-import { CreateUserDTO } from './create-user-dto'
+import { CreateUserDTO, createUserDTOSchema } from './create-user-dto'
 import { CreateUserErrors } from './create-user-errors'
 import { UserValueObjectErrors } from '../../../domain/value-objects/errors'
-import { DecodedExpressRequest } from '../../../../../shared/infra/http/routes/decoded-request'
+import { Result } from '../../../../../shared/core/result'
 
-export class CreateUserController extends BaseController {
+export class CreateUserController extends BaseController<CreateUserDTO> {
   private useCase: CreateUserUseCase
 
   constructor(useCase: CreateUserUseCase) {
@@ -14,10 +15,14 @@ export class CreateUserController extends BaseController {
     this.useCase = useCase
   }
 
-  async executeImpl(req: DecodedExpressRequest, res: express.Response): Promise<express.Response> {
-    // TODO: add class validator/transformer
-    const dto: CreateUserDTO = req.body as CreateUserDTO
+  validate(req: express.Request): Result<CreateUserDTO, ValidationError> {
+    const { error, value } = createUserDTOSchema.validate(req.body)
 
+    if (error) return Result.err(error)
+    return Result.ok(value as CreateUserDTO)
+  }
+
+  async executeImpl(dto: CreateUserDTO, res: express.Response): Promise<express.Response> {
     try {
       const result = await this.useCase.execute(dto)
 

--- a/server/src/modules/users/application/use-cases/create-user/create-user-dto.ts
+++ b/server/src/modules/users/application/use-cases/create-user/create-user-dto.ts
@@ -1,4 +1,11 @@
+import Joi from 'joi'
+
 export interface CreateUserDTO {
   email: string
   password: string
 }
+
+export const createUserDTOSchema = Joi.object({
+  email: Joi.string(),
+  password: Joi.string(),
+}).options({ abortEarly: false })

--- a/server/src/modules/users/infra/http/routes/index.ts
+++ b/server/src/modules/users/infra/http/routes/index.ts
@@ -3,7 +3,7 @@ import { createUserController } from '../../../application/use-cases/create-user
 const userRouter = express.Router()
 
 // routes are coupled to controllers - no need for DI to enable easier testing, that's just overkill
-userRouter.post('/', (req, res) => {
+userRouter.post('/', (req, res): void => {
   createUserController.execute(req, res)
 })
 

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -286,6 +286,18 @@
     is-absolute "^1.0.0"
     is-negated-glob "^1.0.0"
 
+"@hapi/hoek@^9.0.0":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.1.tgz#9daf5745156fd84b8e9889a2dc721f0c58e894aa"
+  integrity sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==
+
+"@hapi/topo@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7"
+  integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@iarna/cli@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@iarna/cli/-/cli-1.2.0.tgz#0f7af5e851afe895104583c4ca07377a8094d641"
@@ -759,6 +771,23 @@
     into-stream "^5.0.0"
     lodash "^4.17.4"
     read-pkg-up "^7.0.0"
+
+"@sideway/address@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.0.tgz#0b301ada10ac4e0e3fa525c90615e0b61a72b78d"
+  integrity sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -4672,6 +4701,17 @@ jest@^26.6.3:
     "@jest/core" "^26.6.3"
     import-local "^3.0.2"
     jest-cli "^26.6.3"
+
+joi@^17.3.0:
+  version "17.3.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.3.0.tgz#f1be4a6ce29bc1716665819ac361dfa139fff5d2"
+  integrity sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Co-authored-by: Justin Xu <xu.justin.j@gmail.com>

We added runtime validation to express' `req.body`. This is needed because there is such thing as guarantees when data is sent over the wire, at run time. What is more of a concern however, is malicious clients sending unsafe payloads to our server. Ensuring the types of our data is important.

`req.body` is the `any` type because we don't know what clients give us. Runtime validation will ensure the shape of the `req.body` is of the shape `{ email: string, password: string }`.

The other possible runtime checking strategies are listed [here](https://learning-notes.mistermicheels.com/javascript/typescript/runtime-type-checking/#runtime-type-checking-strategies)

Manual checks using a validation library make the most sense for our current use cases. It's a sweet middle spot between manually checking with Javascript's `typeof` operator and creating JSON schemas which is a bit overkill for now.

So assuming you agree, the decision comes down to using [Joi](https://joi.dev/) vs [yup](https://github.com/jquense/yup). Since Joi is battle tested at version `17.X` and yup isn't even at `1.0`, we should probably go with `Joi`.

This PR changes the class `BaseController` by adding a generic `DTO` type all concrete implementors must declare. We also added an abstract `validate` method to `BaseController` which will be used to validate the `req.body` before running `execute`